### PR TITLE
[INTERNAL] Coveralls: Use parallel setting to reduce number of PR comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
 		"postversion": "git push --follow-tags",
 		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
-		"report-coveralls": "nyc report --reporter=text-lcov | coveralls"
+		"report-coveralls": "nyc report --reporter=text-lcov | COVERALLS_PARALLEL=true coveralls"
 	},
 	"files": [
 		"index.js",


### PR DESCRIPTION
As per https://docs.coveralls.io/parallel-build-webhook

Only adapt npm script as coveralls is not yet used in this repo