### PR TITLE
[INTERNAL] Reduce log progress text

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -46,9 +46,9 @@ class GroupLogger extends Logger {
 		super(moduleName);
 
 		if (parentLogger) {
-			this._logger = parentLogger._getLogger().newGroup(this._moduleName, weight);
+			this._logger = parentLogger._getLogger().newGroup("", weight);
 		} else {
-			this._logger = npmlog.newGroup(this._moduleName, weight);
+			this._logger = npmlog.newGroup("", weight);
 		}
 	}
 
@@ -69,7 +69,7 @@ class TaskLogger extends Logger {
 		this._completed = 0;
 
 		if (parentLogger) {
-			this._logger = parentLogger._getLogger().newItem(this._moduleName, todo, weight);
+			this._logger = parentLogger._getLogger().newItem("", todo, weight);
 		} else {
 			this._logger = npmlog.newItem(this._moduleName, todo, weight);
 		}


### PR DESCRIPTION
Before:
![screenshot 2018-10-17 at 22 01 24](https://user-images.githubusercontent.com/1589939/47161147-b9be2e00-d2f1-11e8-9ecc-06e86f589f3a.png)

After:
![screenshot 2018-10-17 at 22 01 40](https://user-images.githubusercontent.com/1589939/47161204-de1a0a80-d2f1-11e8-9bb4-c493aacd9336.png)

The long progress text often caused glitches like these:
![screenshot 2018-10-17 at 22 01 12](https://user-images.githubusercontent.com/1589939/47161278-099cf500-d2f2-11e8-9ffc-423ff71bfe71.png)
