### PR TITLE
[FIX] Fix handling of log level "silent"

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 const npmlog = require("npmlog");
 
-const levels = ["silly", "verbose", "info", "warn", "error"];
+const levels = ["silly", "verbose", "info", "warn", "error", "silent"];
 if (process.env.UI5_LOG_LVL) {
 	const logLvl = process.env.UI5_LOG_LVL;
 	if (!levels.includes(logLvl)) {
@@ -129,6 +129,9 @@ module.exports = {
 	},
 
 	setLevel(level) {
+		if (!levels.includes(level)) {
+			throw new Error(`Unkown log level "${level}"`);
+		}
 		return npmlog.level = level;
 	},
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -18,6 +18,22 @@ npmlog.on("error", (err) => {
 	console.log(err);
 });
 
+function isLevelEnabled(levelName) {
+	const currIdx = levels.indexOf(npmlog.level);
+	const reqIdx = levels.indexOf(levelName);
+	if (currIdx === -1) {
+		throw new Error(`Failed to find current log level "${npmlog.level}"" in list of expected log levels`);
+	}
+	if (reqIdx === -1) {
+		throw new Error(`Unkown log level "${levelName}"`);
+	}
+	if (reqIdx >= currIdx) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 class Logger {
 	constructor(moduleName) {
 		this._moduleName = moduleName;
@@ -25,19 +41,7 @@ class Logger {
 	}
 
 	isLevelEnabled(levelName) {
-		const currIdx = levels.indexOf(npmlog.level);
-		const reqIdx = levels.indexOf(levelName);
-		if (currIdx === -1) {
-			throw new Error(`Failed to find current log level ${npmlog.level} in list of expected log levels`);
-		}
-		if (reqIdx === -1) {
-			throw new Error(`Unkown log level "${levelName}"`);
-		}
-		if (reqIdx >= currIdx) {
-			return true;
-		} else {
-			return false;
-		}
+		return isLevelEnabled(levelName);
 	}
 
 	silly(...messages) {
@@ -134,6 +138,8 @@ module.exports = {
 		}
 		return npmlog.level = level;
 	},
+
+	isLevelEnabled,
 
 	setShowProgress(showProgress) {
 		if (showProgress) {


### PR DESCRIPTION
npmlog already supports this level. We just forgot to add it to our
list, causing errors like "Failed to find current log level
"silent" in list of expected log levels" when checking for enabled log
levels.