### PR TITLE
[INTERNAL] Enforce prefix for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,5 @@ updates:
   - matz3
   versioning-strategy: increase
   commit-message:
-    prefix: "[DEPENDENCY]"
-    prefix-development: "[INTERNAL]"
-    include: "scope"
+    prefix: "[DEPENDENCY] "
+    prefix-development: "[INTERNAL] "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,5 @@ updates:
   versioning-strategy: increase
   commit-message:
     prefix: "[DEPENDENCY]"
-    prefix-development: ""
+    prefix-development: "[INTERNAL]"
     include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
   - RandomByte
   - matz3
   versioning-strategy: increase
+  commit-message:
+    prefix: "[DEPENDENCY]"
+    prefix-development: ""
+    include: "scope"


### PR DESCRIPTION
When a commit message starts with `[DEPENDENCY]` we'll create an entry in the changelog when a new release is produced. Therefore we can enforce the usage of this prefix when dependabot creates PRs. `prefix-development` is set to "[INTERNAL]", which will not be listed in the changelog. So only for updates to `dependencies` and not for `devDependencies` a changelog entry is generated. 

Also see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message