### PR TITLE
[INTERNAL] Remove esmock loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 			"test/lib/**/*.js"
 		],
 		"nodeArguments": [
-			"--loader=esmock",
 			"--no-warnings"
 		]
 	},


### PR DESCRIPTION
With https://github.com/SAP/ui5-logger/pull/363 `esmock` was removed from the dependencies but not in the ava test execution. This PR removes the esmock loader extension too.