### PR TITLE
[INTERNAL] Refactor logging modules: Simplify naming

### DIFF
--- a/lib/loggers/Build.js
+++ b/lib/loggers/Build.js
@@ -5,15 +5,15 @@ import Logger from "./Logger.js";
  * <br><br>
  * Emits <code>ui5.log</code>, <code>ui5.build-metadata</code> and <code>ui5.build-status</code> events on the
  * [<code>process</code>]{@link https://nodejs.org/api/process.html} object, which can which can be handled
- * by dedicated handlers, like [@ui5/logger/handlers/ConsoleHandler]{@link @ui5/logger/handlers/ConsoleHandler}.
+ * by dedicated writers, like [@ui5/logger/writers/Console]{@link @ui5/logger/writers/Console}.
  * <br><br>
  * If no listener is attached to the the event, messages are written directly to the <code>process.stderr</code> stream.
  *
  * @private
  * @class
- * @alias @ui5/logger/BuildLogger
+ * @alias @ui5/logger/Build
  */
-class BuildLogger extends Logger {
+class Build extends Logger {
 	#projectsToBuild;
 
 	static BUILD_METADATA_EVENT_NAME = "ui5.build-metadata";
@@ -21,24 +21,24 @@ class BuildLogger extends Logger {
 
 	setProjects(projects) {
 		if (!projects || !Array.isArray(projects)) {
-			throw new Error("BuildLogger#setProjects: Missing or incorrect projects parameter");
+			throw new Error("loggers/Build#setProjects: Missing or incorrect projects parameter");
 		}
 		this.#projectsToBuild = projects;
 
-		this._emit(BuildLogger.BUILD_METADATA_EVENT_NAME, {
+		this._emit(Build.BUILD_METADATA_EVENT_NAME, {
 			projectsToBuild: projects
 		});
 	}
 
 	startProjectBuild(projectName, projectType) {
 		if (!this.#projectsToBuild || !this.#projectsToBuild.includes(projectName)) {
-			throw new Error(`BuildLogger#startProjectBuild: Unknown project ${projectName}`);
+			throw new Error(`loggers/Build#startProjectBuild: Unknown project ${projectName}`);
 		}
 		if (!projectType) {
-			throw new Error(`BuildLogger#startProjectBuild: Missing projectType parameter`);
+			throw new Error(`loggers/Build#startProjectBuild: Missing projectType parameter`);
 		}
 		const level = "info";
-		const hasListeners = this._emit(BuildLogger.BUILD_STATUS_EVENT_NAME, {
+		const hasListeners = this._emit(Build.BUILD_STATUS_EVENT_NAME, {
 			level,
 			projectName,
 			projectType,
@@ -51,13 +51,13 @@ class BuildLogger extends Logger {
 
 	endProjectBuild(projectName, projectType) {
 		if (!this.#projectsToBuild || !this.#projectsToBuild.includes(projectName)) {
-			throw new Error(`BuildLogger#endProjectBuild: Unknown project ${projectName}`);
+			throw new Error(`loggers/Build#endProjectBuild: Unknown project ${projectName}`);
 		}
 		if (!projectType) {
-			throw new Error(`BuildLogger#endProjectBuild: Missing projectType parameter`);
+			throw new Error(`loggers/Build#endProjectBuild: Missing projectType parameter`);
 		}
 		const level = "verbose";
-		const hasListeners = this._emit(BuildLogger.BUILD_STATUS_EVENT_NAME, {
+		const hasListeners = this._emit(Build.BUILD_STATUS_EVENT_NAME, {
 			level,
 			projectName,
 			projectType,
@@ -70,13 +70,13 @@ class BuildLogger extends Logger {
 
 	skipProjectBuild(projectName, projectType) {
 		if (!this.#projectsToBuild || !this.#projectsToBuild.includes(projectName)) {
-			throw new Error(`BuildLogger#skipProjectBuild: Unknown project ${projectName}`);
+			throw new Error(`loggers/Build#skipProjectBuild: Unknown project ${projectName}`);
 		}
 		if (!projectType) {
-			throw new Error(`BuildLogger#skipProjectBuild: Missing projectType parameter`);
+			throw new Error(`loggers/Build#skipProjectBuild: Missing projectType parameter`);
 		}
 		const level = "info";
-		const hasListeners = this._emit(BuildLogger.BUILD_STATUS_EVENT_NAME, {
+		const hasListeners = this._emit(Build.BUILD_STATUS_EVENT_NAME, {
 			level,
 			projectName,
 			projectType,
@@ -88,4 +88,4 @@ class BuildLogger extends Logger {
 	}
 }
 
-export default BuildLogger;
+export default Build;

--- a/lib/loggers/Logger.js
+++ b/lib/loggers/Logger.js
@@ -8,8 +8,8 @@ const rIllegalModuleNameChars = /[^0-9a-zA-Z-_:@.]/i;
  * Standard logging module for UI5 Tooling and extensions.
  * <br><br>
  * Emits <code>ui5.log</code> events on the [<code>process</code>]{@link https://nodejs.org/api/process.html} object,
- * which can be handled by dedicated handlers,
- * like [@ui5/logger/handlers/ConsoleHandler]{@link @ui5/logger/handlers/ConsoleHandler}.
+ * which can be handled by dedicated writers,
+ * like [@ui5/logger/writers/Console]{@link @ui5/logger/writers/Console}.
  * <br><br>
  * If no listener is attached to an event, messages are written directly to the <code>process.stderr</code> stream.
  *

--- a/lib/loggers/ProjectBuild.js
+++ b/lib/loggers/ProjectBuild.js
@@ -5,16 +5,16 @@ import Logger from "./Logger.js";
  * <br><br>
  * Emits <code>ui5.log</code>, <code>ui5.project-build-metadata</code> and <code>ui5.project-build-status</code>
  * events on the [<code>process</code>]{@link https://nodejs.org/api/process.html} object,
- * which can be handled by dedicated handlers,
- * like [@ui5/logger/handlers/ConsoleHandler]{@link @ui5/logger/handlers/ConsoleHandler}.
+ * which can be handled by dedicated writers,
+ * like [@ui5/logger/writers/Console]{@link @ui5/logger/writers/Console}.
  * <br><br>
  * If no listener is attached to the the event, messages are written directly to the <code>process.stderr</code> stream.
  *
  * @private
  * @class
- * @alias @ui5/logger/ProjectBuildLogger
+ * @alias @ui5/logger/ProjectBuild
  */
-class ProjectBuildLogger extends Logger {
+class ProjectBuild extends Logger {
 	#projectName;
 	#projectType;
 	#tasksToRun;
@@ -26,10 +26,10 @@ class ProjectBuildLogger extends Logger {
 		super(moduleName);
 
 		if (!projectName) {
-			throw new Error("ProjectBuildLogger: Missing projectName parameter");
+			throw new Error("loggers/ProjectBuild: Missing projectName parameter");
 		}
 		if (!projectType) {
-			throw new Error("ProjectBuildLogger: Missing projectType parameter");
+			throw new Error("loggers/ProjectBuild: Missing projectType parameter");
 		}
 		this.#projectName = projectName;
 		this.#projectType = projectType;
@@ -37,11 +37,11 @@ class ProjectBuildLogger extends Logger {
 
 	setTasks(tasks) {
 		if (!tasks || !Array.isArray(tasks)) {
-			throw new Error("ProjectBuildLogger#setTasks: Missing or incorrect tasks parameter");
+			throw new Error("loggers/ProjectBuild#setTasks: Missing or incorrect tasks parameter");
 		}
 		this.#tasksToRun = tasks;
 
-		this._emit(ProjectBuildLogger.PROJECT_BUILD_METADATA_EVENT_NAME, {
+		this._emit(ProjectBuild.PROJECT_BUILD_METADATA_EVENT_NAME, {
 			projectName: this.#projectName,
 			projectType: this.#projectType,
 			tasksToRun: tasks
@@ -50,10 +50,10 @@ class ProjectBuildLogger extends Logger {
 
 	startTask(taskName) {
 		if (!this.#tasksToRun || !this.#tasksToRun.includes(taskName)) {
-			throw new Error(`ProjectBuildLogger#startTask: Unknown task ${taskName}`);
+			throw new Error(`loggers/ProjectBuild#startTask: Unknown task ${taskName}`);
 		}
 		const level = "info";
-		const hasListeners = this._emit(ProjectBuildLogger.PROJECT_BUILD_STATUS_EVENT_NAME, {
+		const hasListeners = this._emit(ProjectBuild.PROJECT_BUILD_STATUS_EVENT_NAME, {
 			level,
 			projectName: this.#projectName,
 			projectType: this.#projectType,
@@ -68,10 +68,10 @@ class ProjectBuildLogger extends Logger {
 
 	endTask(taskName) {
 		if (!this.#tasksToRun || !this.#tasksToRun.includes(taskName)) {
-			throw new Error(`ProjectBuildLogger#endTask: Unknown task ${taskName}`);
+			throw new Error(`loggers/ProjectBuild#endTask: Unknown task ${taskName}`);
 		}
 		const level = "verbose";
-		const hasListeners = this._emit(ProjectBuildLogger.PROJECT_BUILD_STATUS_EVENT_NAME, {
+		const hasListeners = this._emit(ProjectBuild.PROJECT_BUILD_STATUS_EVENT_NAME, {
 			level,
 			projectName: this.#projectName,
 			projectType: this.#projectType,
@@ -85,4 +85,4 @@ class ProjectBuildLogger extends Logger {
 	}
 }
 
-export default ProjectBuildLogger;
+export default ProjectBuild;

--- a/lib/writers/Console.js
+++ b/lib/writers/Console.js
@@ -14,9 +14,9 @@ import Logger from "../loggers/Logger.js";
  *
  * @public
  * @class
- * @alias @ui5/logger/handlers/ConsoleHandler
+ * @alias @ui5/logger/writers/Console
  */
-class ConsoleHandler {
+class Console {
 	#projectMetadata = new Map();
 	#progressBarContainer;
 	#progressBar;
@@ -134,7 +134,7 @@ class ConsoleHandler {
 	}
 
 	#handleLogEvent({level, message, moduleName}) {
-		this.#writeMessage(level, `${chalk.blue(moduleName)}: ${message}`);
+		this.#writeMessage(level, `${chalk.blue(moduleName)} ${message}`);
 	}
 
 	#handleBuildMetadataEvent({projectsToBuild}) {
@@ -165,7 +165,7 @@ class ConsoleHandler {
 	#getProjectMetadata(projectName) {
 		const projectMetadata = this.#projectMetadata.get(projectName);
 		if (!projectMetadata) {
-			throw new Error(`ConsoleHandler: Unknown project ${projectName}`);
+			throw new Error(`ConsoleWriter: Unknown project ${projectName}`);
 		}
 		return projectMetadata;
 	}
@@ -201,16 +201,16 @@ class ConsoleHandler {
 		case "project-build-start":
 			if (projectMetadata.buildEnded) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-start event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-start event for project ${projectName}. ` +
 					`Project build already ended`);
 			}
 			if (projectMetadata.buildStarted) {
 				throw new Error(
-					`ConsoleHandler: Unexpected duplicate project-build-start event for project ${projectName}`);
+					`ConsoleWriter: Unexpected duplicate project-build-start event for project ${projectName}`);
 			}
 			if (projectMetadata.buildSkipped) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-start event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-start event for project ${projectName}. ` +
 					`Project build already skipped`);
 			}
 			projectMetadata.buildStarted = true;
@@ -225,16 +225,16 @@ class ConsoleHandler {
 		case "project-build-end":
 			if (projectMetadata.buildEnded) {
 				throw new Error(
-					`ConsoleHandler: Unexpected duplicate project-build-end event for project ${projectName}`);
+					`ConsoleWriter: Unexpected duplicate project-build-end event for project ${projectName}`);
 			}
 			if (projectMetadata.buildSkipped) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-end event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-end event for project ${projectName}. ` +
 					`Project build already skipped`);
 			}
 			if (!projectMetadata.buildStarted) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-end event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-end event for project ${projectName}. ` +
 					`No corresponding project-build-start event handled`);
 			}
 			projectMetadata.buildEnded = true;
@@ -247,16 +247,16 @@ class ConsoleHandler {
 		case "project-build-skip":
 			if (projectMetadata.buildSkipped) {
 				throw new Error(
-					`ConsoleHandler: Unexpected duplicate project-build-skip event for project ${projectName}`);
+					`ConsoleWriter: Unexpected duplicate project-build-skip event for project ${projectName}`);
 			}
 			if (projectMetadata.buildEnded) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-skip event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-skip event for project ${projectName}. ` +
 					`Project build already ended`);
 			}
 			if (projectMetadata.buildStarted) {
 				throw new Error(
-					`ConsoleHandler: Unexpected project-build-skip event for project ${projectName}. ` +
+					`ConsoleWriter: Unexpected project-build-skip event for project ${projectName}. ` +
 					`Project build already started`);
 			}
 			projectMetadata.buildSkipped = true;
@@ -269,7 +269,7 @@ class ConsoleHandler {
 			break;
 		default:
 			this.#writeMessage("verbose",
-				`ConsoleHandler: Received unknown build-status ${status} for project ${projectName}`);
+				`ConsoleWriter: Received unknown build-status ${status} for project ${projectName}`);
 			return;
 		}
 
@@ -280,7 +280,7 @@ class ConsoleHandler {
 		const {projectTasks} = this.#getProjectMetadata(projectName);
 		const taskMetadata = projectTasks.get(taskName);
 		if (!taskMetadata) {
-			throw new Error(`ConsoleHandler: Unknown task ${taskName} for project ${projectName}`);
+			throw new Error(`ConsoleWriter: Unknown task ${taskName} for project ${projectName}`);
 		}
 		if (taskMetadata.executionStartIndex === null) {
 			let nextIdx = 1;
@@ -301,11 +301,11 @@ class ConsoleHandler {
 		case "task-start":
 			if (taskMetadata.executionEnded) {
 				throw new Error(
-					`ConsoleHandler: Unexpected task-start event for project ${projectName}, task ${taskName}. ` +
+					`ConsoleWriter: Unexpected task-start event for project ${projectName}, task ${taskName}. ` +
 					`Task execution already ended`);
 			}
 			if (taskMetadata.executionStarted) {
-				throw new Error(`ConsoleHandler: Unexpected duplicate task-start event ` +
+				throw new Error(`ConsoleWriter: Unexpected duplicate task-start event ` +
 					`for project ${projectName}, task ${taskName}`);
 			}
 			taskMetadata.executionStarted = true;
@@ -314,11 +314,11 @@ class ConsoleHandler {
 		case "task-end":
 			if (taskMetadata.executionEnded) {
 				throw new Error(
-					`ConsoleHandler: Unexpected duplicate task-end event for project ${projectName}, task ${taskName}`);
+					`ConsoleWriter: Unexpected duplicate task-end event for project ${projectName}, task ${taskName}`);
 			}
 			if (!taskMetadata.executionStarted) {
 				throw new Error(
-					`ConsoleHandler: Unexpected task-end event for project ${projectName}, task ${taskName}. ` +
+					`ConsoleWriter: Unexpected task-end event for project ${projectName}, task ${taskName}. ` +
 					`No corresponding task-start event handled`);
 			}
 			taskMetadata.executionEnded = true;
@@ -329,7 +329,7 @@ class ConsoleHandler {
 			break;
 		default:
 			this.#writeMessage("verbose",
-				`ConsoleHandler: Received unknown project-build-status ${status} for project ${projectName}`);
+				`ConsoleWriter: Received unknown project-build-status ${status} for project ${projectName}`);
 			return;
 		}
 
@@ -362,10 +362,10 @@ class ConsoleHandler {
 	 * @public
 	 */
 	static init() {
-		const cH = new ConsoleHandler();
+		const cH = new Console();
 		cH.enable();
 		return cH;
 	}
 }
 
-export default ConsoleHandler;
+export default Console;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
 	"type": "module",
 	"exports": {
 		".": "./lib/index.js",
-		"./*": "./lib/loggers/*.js",
-		"./handlers/*": "./lib/handlers/*.js",
-		"./package.json": "./package.json"
+		"./loggers/Logger": "./lib/loggers/Logger.js",
+		"./writers/*": "./lib/writers/*.js",
+		"./package.json": "./package.json",
+		"./internal/loggers/*": "./lib/loggers/*.js"
 	},
 	"engines": {
 		"node": "^16.18.0 || >=18.0.0",
@@ -46,7 +47,7 @@
 		"version": "git-chglog --sort semver --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
 		"postversion": "git push --follow-tags",
 		"release-note": "git-chglog --sort semver -c .chglog/release-config.yml v$npm_package_version",
-		"depcheck": "depcheck --ignores docdash,@istanbuljs/esm-loader-hook"
+		"depcheck": "depcheck --ignores @ui5/logger,docdash,@istanbuljs/esm-loader-hook"
 	},
 	"files": [
 		"CHANGELOG.md",

--- a/test/lib/loggers/Build.js
+++ b/test/lib/loggers/Build.js
@@ -1,6 +1,6 @@
 import test from "ava";
 import sinon from "sinon";
-import BuildLogger from "../../../lib/loggers/BuildLogger.js";
+import BuildLogger from "../../../lib/loggers/Build.js";
 
 test.serial.beforeEach((t) => {
 	t.context.buildLogger = new BuildLogger("my:module:name");
@@ -189,13 +189,13 @@ test.serial("Set projects: Missing parameter", (t) => {
 	t.throws(() => {
 		buildLogger.setProjects();
 	}, {
-		message: `BuildLogger#setProjects: Missing or incorrect projects parameter`
+		message: `loggers/Build#setProjects: Missing or incorrect projects parameter`
 	}, "Threw with expected error message");
 
 	t.throws(() => {
 		buildLogger.setProjects(new Set("no array"));
 	}, {
-		message: `BuildLogger#setProjects: Missing or incorrect projects parameter`
+		message: `loggers/Build#setProjects: Missing or incorrect projects parameter`
 	}, "Threw with expected error message");
 });
 
@@ -206,7 +206,7 @@ test.serial("Start project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.startProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#startProjectBuild: Unknown project project.x`
+		message: `loggers/Build#startProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 
 	buildLogger.setProjects(["project.a"]);
@@ -214,7 +214,7 @@ test.serial("Start project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.startProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#startProjectBuild: Unknown project project.x`
+		message: `loggers/Build#startProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 });
 
@@ -225,7 +225,7 @@ test.serial("End project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.endProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#endProjectBuild: Unknown project project.x`
+		message: `loggers/Build#endProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 
 	buildLogger.setProjects(["project.a"]);
@@ -233,7 +233,7 @@ test.serial("End project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.endProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#endProjectBuild: Unknown project project.x`
+		message: `loggers/Build#endProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 });
 
@@ -244,7 +244,7 @@ test.serial("Skip project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.skipProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#skipProjectBuild: Unknown project project.x`
+		message: `loggers/Build#skipProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 
 	buildLogger.setProjects(["project.a"]);
@@ -252,7 +252,7 @@ test.serial("Skip project build: Unknown project", (t) => {
 	t.throws(() => {
 		buildLogger.skipProjectBuild("project.x", "application");
 	}, {
-		message: `BuildLogger#skipProjectBuild: Unknown project project.x`
+		message: `loggers/Build#skipProjectBuild: Unknown project project.x`
 	}, "Threw with expected error message");
 });
 
@@ -263,7 +263,7 @@ test.serial("Start project build: Missing projectType parameter", (t) => {
 	t.throws(() => {
 		buildLogger.startProjectBuild("project.a");
 	}, {
-		message: `BuildLogger#startProjectBuild: Missing projectType parameter`
+		message: `loggers/Build#startProjectBuild: Missing projectType parameter`
 	}, "Threw with expected error message");
 });
 
@@ -274,7 +274,7 @@ test.serial("End project build: Missing projectType parameter", (t) => {
 	t.throws(() => {
 		buildLogger.endProjectBuild("project.a");
 	}, {
-		message: `BuildLogger#endProjectBuild: Missing projectType parameter`
+		message: `loggers/Build#endProjectBuild: Missing projectType parameter`
 	}, "Threw with expected error message");
 });
 
@@ -285,6 +285,6 @@ test.serial("Skip project build: Missing projectType parameter", (t) => {
 	t.throws(() => {
 		buildLogger.skipProjectBuild("project.a");
 	}, {
-		message: `BuildLogger#skipProjectBuild: Missing projectType parameter`
+		message: `loggers/Build#skipProjectBuild: Missing projectType parameter`
 	}, "Threw with expected error message");
 });

--- a/test/lib/loggers/ProjectBuild.js
+++ b/test/lib/loggers/ProjectBuild.js
@@ -1,6 +1,6 @@
 import test from "ava";
 import sinon from "sinon";
-import ProjectBuildLogger from "../../../lib/loggers/ProjectBuildLogger.js";
+import ProjectBuildLogger from "../../../lib/loggers/ProjectBuild.js";
 
 test.serial.beforeEach((t) => {
 	t.context.projectBuildLogger = new ProjectBuildLogger({
@@ -50,7 +50,7 @@ test.serial("Missing parameters", (t) => {
 			projectName: "projectName",
 		});
 	}, {
-		message: "ProjectBuildLogger: Missing projectType parameter"
+		message: "loggers/ProjectBuild: Missing projectType parameter"
 	}, "Threw with expected error message");
 
 	t.throws(() => {
@@ -59,7 +59,7 @@ test.serial("Missing parameters", (t) => {
 			projectType: "projectType",
 		});
 	}, {
-		message: "ProjectBuildLogger: Missing projectName parameter"
+		message: "loggers/ProjectBuild: Missing projectName parameter"
 	}, "Threw with expected error message");
 });
 
@@ -180,13 +180,13 @@ test.serial("Set tasks: Missing parameter", (t) => {
 	t.throws(() => {
 		projectBuildLogger.setTasks();
 	}, {
-		message: `ProjectBuildLogger#setTasks: Missing or incorrect tasks parameter`
+		message: `loggers/ProjectBuild#setTasks: Missing or incorrect tasks parameter`
 	}, "Threw with expected error message");
 
 	t.throws(() => {
 		projectBuildLogger.setTasks(new Set("no array"));
 	}, {
-		message: `ProjectBuildLogger#setTasks: Missing or incorrect tasks parameter`
+		message: `loggers/ProjectBuild#setTasks: Missing or incorrect tasks parameter`
 	}, "Threw with expected error message");
 });
 
@@ -197,7 +197,7 @@ test.serial("Start task: Unknown task", (t) => {
 	t.throws(() => {
 		projectBuildLogger.startTask("task.x");
 	}, {
-		message: `ProjectBuildLogger#startTask: Unknown task task.x`
+		message: `loggers/ProjectBuild#startTask: Unknown task task.x`
 	}, "Threw with expected error message");
 
 	projectBuildLogger.setTasks(["task.a"]);
@@ -205,7 +205,7 @@ test.serial("Start task: Unknown task", (t) => {
 	t.throws(() => {
 		projectBuildLogger.startTask("task.x");
 	}, {
-		message: `ProjectBuildLogger#startTask: Unknown task task.x`
+		message: `loggers/ProjectBuild#startTask: Unknown task task.x`
 	}, "Threw with expected error message");
 });
 
@@ -216,7 +216,7 @@ test.serial("End task: Unknown task", (t) => {
 	t.throws(() => {
 		projectBuildLogger.endTask("task.x");
 	}, {
-		message: `ProjectBuildLogger#endTask: Unknown task task.x`
+		message: `loggers/ProjectBuild#endTask: Unknown task task.x`
 	}, "Threw with expected error message");
 
 	projectBuildLogger.setTasks(["task.a"]);
@@ -224,7 +224,7 @@ test.serial("End task: Unknown task", (t) => {
 	t.throws(() => {
 		projectBuildLogger.endTask("task.x");
 	}, {
-		message: `ProjectBuildLogger#endTask: Unknown task task.x`
+		message: `loggers/ProjectBuild#endTask: Unknown task task.x`
 	}, "Threw with expected error message");
 });
 

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -1,0 +1,45 @@
+import test from "ava";
+import {createRequire} from "node:module";
+
+// Using CommonsJS require as importing json files causes an ExperimentalWarning
+const require = createRequire(import.meta.url);
+
+// package.json should be exported to allow reading version (e.g. from @ui5/cli)
+test("export of package.json", (t) => {
+	t.truthy(require("@ui5/logger/package.json").version);
+});
+
+// Check number of definied exports
+test("check number of exports", (t) => {
+	const packageJson = require("@ui5/logger/package.json");
+	t.is(Object.keys(packageJson.exports).length, 5);
+});
+
+// Public API contract (exported modules)
+[
+	"loggers/Logger",
+	"writers/Console",
+
+	// Internal modules (only to be used by @ui5/* packages)
+	{exportedSpecifier: "internal/loggers/Logger", mappedModule: "../../lib/loggers/Logger.js"},
+	{exportedSpecifier: "internal/loggers/Build", mappedModule: "../../lib/loggers/Build.js"},
+	{exportedSpecifier: "internal/loggers/ProjectBuild", mappedModule: "../../lib/loggers/ProjectBuild.js"},
+].forEach((v) => {
+	let exportedSpecifier; let mappedModule;
+	if (typeof v === "string") {
+		exportedSpecifier = v;
+	} else {
+		exportedSpecifier = v.exportedSpecifier;
+		mappedModule = v.mappedModule;
+	}
+	if (!mappedModule) {
+		mappedModule = `../../lib/${exportedSpecifier}.js`;
+	}
+	const spec = `@ui5/logger/${exportedSpecifier}`;
+	test(`${spec}`, async (t) => {
+		const actual = await import(spec);
+		const expected = await import(mappedModule);
+		t.is(actual, expected, "Correct module exported");
+	});
+});
+

--- a/test/lib/writers/Console.js
+++ b/test/lib/writers/Console.js
@@ -2,17 +2,17 @@ import test from "ava";
 import sinon from "sinon";
 import stripAnsi from "strip-ansi";
 import figures from "figures";
-import ConsoleHandler from "../../../lib/handlers/ConsoleHandler.js";
+import ConsoleWriter from "../../../lib/writers/Console.js";
 
 test.serial.beforeEach((t) => {
-	t.context.consoleHandler = ConsoleHandler.init();
+	t.context.consoleWriter = ConsoleWriter.init();
 	t.context.stderrWriteStub = sinon.stub(process.stderr, "write");
 	t.context.originalIsTty = process.stderr.isTTY;
 	process.env.UI5_LOG_LVL = "info";
 });
 
 test.serial.afterEach.always((t) => {
-	t.context.consoleHandler.disable();
+	t.context.consoleWriter.disable();
 	sinon.restore();
 	process.stderr.isTTY = t.context.originalIsTty;
 	delete process.env.UI5_LOG_LVL;
@@ -28,13 +28,13 @@ test.serial("Log event", (t) => {
 	});
 
 	t.is(stderrWriteStub.callCount, 1, "Logged one message");
-	t.is(stripAnsi(stderrWriteStub.getCall(0).args[0]), `info my:module: Message 1\n`,
+	t.is(stripAnsi(stderrWriteStub.getCall(0).args[0]), `info my:module Message 1\n`,
 		"Logged expected message");
 });
 
 test.serial("Disable", (t) => {
-	const {consoleHandler, stderrWriteStub} = t.context;
-	consoleHandler.disable();
+	const {consoleWriter, stderrWriteStub} = t.context;
+	consoleWriter.disable();
 
 	process.emit("ui5.log", {
 		level: "info",
@@ -46,8 +46,8 @@ test.serial("Disable", (t) => {
 });
 
 test.serial("Enable", (t) => {
-	const {consoleHandler, stderrWriteStub} = t.context;
-	consoleHandler.disable();
+	const {consoleWriter, stderrWriteStub} = t.context;
+	consoleWriter.disable();
 
 	process.emit("ui5.log", {
 		level: "info",
@@ -57,7 +57,7 @@ test.serial("Enable", (t) => {
 
 	t.is(stderrWriteStub.callCount, 0, "Logged no message");
 
-	consoleHandler.enable();
+	consoleWriter.enable();
 	process.emit("ui5.log", {
 		level: "info",
 		message: "Message 2",
@@ -66,7 +66,7 @@ test.serial("Enable", (t) => {
 
 	t.is(stderrWriteStub.callCount, 1, "Logged no message");
 	t.is(stripAnsi(stderrWriteStub.getCall(0).args[0]),
-		`info my:module: Message 2\n`,
+		`info my:module Message 2\n`,
 		"Logged expected message");
 });
 
@@ -135,7 +135,7 @@ test.serial("Build status: Unknown project", (t) => {
 			status: "project-build-start",
 		});
 	}, {
-		message: "ConsoleHandler: Unknown project project.a"
+		message: "ConsoleWriter: Unknown project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -162,7 +162,7 @@ test.serial("Build status (start): Duplicate project build start", (t) => {
 			status: "project-build-start",
 		});
 	}, {
-		message: "ConsoleHandler: Unexpected duplicate project-build-start event for project project.a"
+		message: "ConsoleWriter: Unexpected duplicate project-build-start event for project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -197,7 +197,7 @@ test.serial("Build status (start): Project build already ended", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-start event for project project.a. Project build already ended"
+			"ConsoleWriter: Unexpected project-build-start event for project project.a. Project build already ended"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -225,7 +225,7 @@ test.serial("Build status (start): Project build already skipped", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-start event for project project.a. " +
+			"ConsoleWriter: Unexpected project-build-start event for project project.a. " +
 			"Project build already skipped"
 	});
 
@@ -260,7 +260,7 @@ test.serial("Build status (end): Duplicate project build end", (t) => {
 			status: "project-build-end",
 		});
 	}, {
-		message: "ConsoleHandler: Unexpected duplicate project-build-end event for project project.a"
+		message: "ConsoleWriter: Unexpected duplicate project-build-end event for project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -281,7 +281,7 @@ test.serial("Build status (end): Project build not started", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-end event for project project.a. " +
+			"ConsoleWriter: Unexpected project-build-end event for project project.a. " +
 			"No corresponding project-build-start event handled"
 	});
 
@@ -310,7 +310,7 @@ test.serial("Build status (end): Project build already skipped", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-end event for project project.a. " +
+			"ConsoleWriter: Unexpected project-build-end event for project project.a. " +
 			"Project build already skipped"
 	});
 
@@ -338,7 +338,7 @@ test.serial("Build status (skip): Duplicate project build skip", (t) => {
 			status: "project-build-skip",
 		});
 	}, {
-		message: "ConsoleHandler: Unexpected duplicate project-build-skip event for project project.a"
+		message: "ConsoleWriter: Unexpected duplicate project-build-skip event for project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -366,7 +366,7 @@ test.serial("Build status (skip): Project build already started", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-skip event for project project.a. " +
+			"ConsoleWriter: Unexpected project-build-skip event for project project.a. " +
 			"Project build already started"
 	});
 
@@ -402,7 +402,7 @@ test.serial("Build status (skip): Project build already ended", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected project-build-skip event for project project.a. " +
+			"ConsoleWriter: Unexpected project-build-skip event for project project.a. " +
 			"Project build already ended"
 	});
 
@@ -425,7 +425,7 @@ test.serial("Build status: Unknown status", (t) => {
 
 	t.is(stderrWriteStub.callCount, 1, "Logged one message");
 	t.is(stripAnsi(stderrWriteStub.firstCall.firstArg),
-		`verb ConsoleHandler: Received unknown build-status foo for project project.a\n`,
+		`verb ConsoleWriter: Received unknown build-status foo for project project.a\n`,
 		"Logged expected message");
 });
 
@@ -475,7 +475,7 @@ test.serial("ProjectBuild status: Unknown project", (t) => {
 			status: "task-end",
 		});
 	}, {
-		message: "ConsoleHandler: Unknown project project.a"
+		message: "ConsoleWriter: Unknown project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -496,7 +496,7 @@ test.serial("ProjectBuild status: Unknown task", (t) => {
 			status: "task-end",
 		});
 	}, {
-		message: "ConsoleHandler: Unknown task task.a for project project.a"
+		message: "ConsoleWriter: Unknown task task.a for project project.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -532,7 +532,7 @@ test.serial("ProjectBuild status (start): Duplicate task execution start", (t) =
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected duplicate task-start event for project project.a, task task.a"
+			"ConsoleWriter: Unexpected duplicate task-start event for project project.a, task task.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -576,7 +576,7 @@ test.serial("ProjectBuild status (start): Task execution already ended", (t) => 
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected task-start event for project project.a, task task.a. " +
+			"ConsoleWriter: Unexpected task-start event for project project.a, task task.a. " +
 			"Task execution already ended"
 	});
 
@@ -621,7 +621,7 @@ test.serial("ProjectBuild status (end): Duplicate task execution end", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected duplicate task-end event for project project.a, task task.a"
+			"ConsoleWriter: Unexpected duplicate task-end event for project project.a, task task.a"
 	});
 
 	t.is(stderrWriteStub.callCount, 0, "Logged zero messages");
@@ -649,7 +649,7 @@ test.serial("ProjectBuild status (end): Task execution not started", (t) => {
 		});
 	}, {
 		message:
-			"ConsoleHandler: Unexpected task-end event for project project.a, task task.a. " +
+			"ConsoleWriter: Unexpected task-end event for project project.a, task task.a. " +
 			"No corresponding task-start event handled"
 	});
 
@@ -679,29 +679,29 @@ test.serial("ProjectBuild status: Unknown status", (t) => {
 
 	t.is(stderrWriteStub.callCount, 1, "Logged one message");
 	t.is(stripAnsi(stderrWriteStub.firstCall.firstArg),
-		`verb ConsoleHandler: Received unknown project-build-status foo for project project.a\n`,
+		`verb ConsoleWriter: Received unknown project-build-status foo for project project.a\n`,
 		"Logged expected message");
 });
 
 test.serial("No progress bar in test environment", (t) => {
-	const {consoleHandler} = t.context;
+	const {consoleWriter} = t.context;
 
 	// Since there is no interactive terminal, progress bar should not be used/returned
-	t.falsy(consoleHandler._getProgressBar(), "No progress bar returned");
+	t.falsy(consoleWriter._getProgressBar(), "No progress bar returned");
 });
 
 test.serial("No progress bar for log level verbose", (t) => {
-	const {consoleHandler} = t.context;
+	const {consoleWriter} = t.context;
 
 	process.stderr.isTTY = true;
 	process.env.UI5_LOG_LVL = "verbose";
 
 	// Since there is no interactive terminal, progress bar should not be used/returned
-	t.falsy(consoleHandler._getProgressBar(), "No progress bar returned");
+	t.falsy(consoleWriter._getProgressBar(), "No progress bar returned");
 });
 
 test.serial("Progress bar completion does not drop any logs", async (t) => {
-	const {consoleHandler, stderrWriteStub} = t.context;
+	const {consoleWriter, stderrWriteStub} = t.context;
 
 	// Force TTY in test env to enable progress bar
 	process.stderr.isTTY = true;
@@ -710,7 +710,7 @@ test.serial("Progress bar completion does not drop any logs", async (t) => {
 		projectsToBuild: ["project.a"]
 	});
 
-	const pb = consoleHandler._getProgressBar();
+	const pb = consoleWriter._getProgressBar();
 
 	t.true(pb.isActive, "Progress bar is active");
 
@@ -755,7 +755,7 @@ test.serial("Progress bar completion does not drop any logs", async (t) => {
 	});
 	t.truthy(firstMessage, "Logged first message");
 	t.is(stripAnsi(firstMessage.firstArg),
-		`info my:module: Message 1\n`,
+		`info my:module Message 1\n`,
 		"Logged expected first message");
 
 	const secondMessage = allWriteCalls.find((call) => {
@@ -763,7 +763,7 @@ test.serial("Progress bar completion does not drop any logs", async (t) => {
 	});
 	t.truthy(secondMessage, "Logged second message");
 	t.is(stripAnsi(secondMessage.firstArg),
-		`info my:module: Message 2\n`,
+		`info my:module Message 2\n`,
 		"Logged expected second message");
 
 	const thirdMessage = allWriteCalls.find((call) => {
@@ -771,12 +771,12 @@ test.serial("Progress bar completion does not drop any logs", async (t) => {
 	});
 	t.truthy(thirdMessage, "Logged third message");
 	t.is(stripAnsi(thirdMessage.firstArg),
-		`info my:module: Message 3\n`,
+		`info my:module Message 3\n`,
 		"Logged expected third message");
 });
 
 test.serial("Disable: Stops progress bar", (t) => {
-	const {consoleHandler, stderrWriteStub} = t.context;
+	const {consoleWriter, stderrWriteStub} = t.context;
 
 	// Force TTY in test env to enable progress bar
 	process.stderr.isTTY = true;
@@ -785,17 +785,17 @@ test.serial("Disable: Stops progress bar", (t) => {
 		projectsToBuild: ["project.a"]
 	});
 
-	const pb = consoleHandler._getProgressBar();
+	const pb = consoleWriter._getProgressBar();
 
 	t.true(pb.isActive, "Progress bar is active");
 
-	consoleHandler.disable();
+	consoleWriter.disable();
 	stderrWriteStub.resetHistory();
 
 	t.false(pb.isActive, "Progress bar is not active anymore");
 
 	// Re-enable and log a message
-	consoleHandler.enable();
+	consoleWriter.enable();
 	process.emit("ui5.log", {
 		level: "info",
 		message: "Message 1",


### PR DESCRIPTION
* handlers/ConsoleHandler => writers/Console
* loggers/BuildLogger => loggers/Build
* loggers/ProjectBuildLogger => loggers/ProjectBuild

Also, only the modules "logger/Logger" and "writers/Console" are
exported directly. The Build-loggers are exported as "internal".

Add test for package.json exports.

writers/Console: Remove colon after module name to align with old
logging.