### PR TITLE
[INTERNAL] index.js: Refactor to named exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ import Logger from "./loggers/Logger.js";
  * @public
  * @param {string} moduleName Identifier for messages created by the logger.
  * Example: <code>module:submodule:Class</code>
- * @returns {@ui5/logger/loggers/Logger}
+ * @returns {@ui5/logger/Logger}
  */
 export function getLogger(moduleName) {
 	return new Logger(moduleName);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,48 +6,46 @@ import Logger from "./loggers/Logger.js";
  * @public
  * @module @ui5/logger
  */
-export default {
 
-	/**
-	 * Convenience function to create an instance of [@ui5/logger/loggers/Logger]{@link @ui5/logger/loggers/Logger}
-	 *
-	 * @public
-	 * @param {string} moduleName Identifier for messages created by the logger.
-	 * Example: <code>module:submodule:Class</code>
-	 * @returns {@ui5/logger/loggers/Logger}
-	 */
-	getLogger: (moduleName) => {
-		return new Logger(moduleName);
-	},
+/**
+ * Convenience function to create an instance of [@ui5/logger/loggers/Logger]{@link @ui5/logger/loggers/Logger}
+ *
+ * @public
+ * @param {string} moduleName Identifier for messages created by the logger.
+ * Example: <code>module:submodule:Class</code>
+ * @returns {@ui5/logger/loggers/Logger}
+ */
+export function getLogger(moduleName) {
+	return new Logger(moduleName);
+}
 
-	/**
-	 * Tests whether the provided log level is enabled by the current log level
-	 *
-	 * @public
-	 * @function
-	 * @param {string} levelName Log level to test
-	 * @returns {boolean} True if the provided level is enabled
-	 */
-	isLevelEnabled: Logger.isLevelEnabled,
+/**
+ * Tests whether the provided log level is enabled by the current log level
+ *
+ * @public
+ * @function
+ * @param {string} levelName Log level to test
+ * @returns {boolean} True if the provided level is enabled
+ */
+export const isLogLevelEnabled = Logger.isLevelEnabled;
 
-	/**
-	 * Sets the standard log level.
-	 * <br>
-	 * <b>Example:</b> Setting it to <code>perf</code> would suppress all <code>silly</code> and <code>verbose</code>
-	 * logging, and only show <code>perf</code>, <code>info</code>, <code>warn</code> and <code>error</code> logs.
-	 *
-	 * @public
-	 * @function
-	 * @param {string} levelName New log level
-	 */
-	setLevel: Logger.setLevel,
+/**
+ * Sets the standard log level.
+ * <br>
+ * <b>Example:</b> Setting it to <code>perf</code> would suppress all <code>silly</code> and <code>verbose</code>
+ * logging, and only show <code>perf</code>, <code>info</code>, <code>warn</code> and <code>error</code> logs.
+ *
+ * @public
+ * @function
+ * @param {string} levelName New log level
+ */
+export const setLogLevel = Logger.setLevel;
 
-	/**
-	 * Gets the current log level
-	 *
-	 * @public
-	 * @function
-	 * @returns {string} The current log level. Defaults to <code>info</code>
-	 */
-	getLevel: Logger.getLevel,
-};
+/**
+ * Gets the current log level
+ *
+ * @public
+ * @function
+ * @returns {string} The current log level. Defaults to <code>info</code>
+ */
+export const getLogLevel = Logger.getLevel;

--- a/lib/loggers/Logger.js
+++ b/lib/loggers/Logger.js
@@ -2,7 +2,7 @@ import process from "node:process";
 import {inspect} from "node:util";
 
 // Module name must not contain any other characters than alphanumerical and some specials
-const rIllegalModuleNameChars = /[^0-9a-zA-Z-_:@.]/i;
+const rIllegalModuleNameChars = /[^0-9a-zA-Z-_:@./]/i;
 
 /**
  * Standard logging module for UI5 Tooling and extensions.

--- a/lib/loggers/Logger.js
+++ b/lib/loggers/Logger.js
@@ -15,7 +15,7 @@ const rIllegalModuleNameChars = /[^0-9a-zA-Z-_:@.]/i;
  *
  * @public
  * @class
- * @alias @ui5/logger/loggers/Logger
+ * @alias @ui5/logger/Logger
  */
 class Logger {
 	/**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"type": "module",
 	"exports": {
 		".": "./lib/index.js",
-		"./loggers/Logger": "./lib/loggers/Logger.js",
+		"./Logger": "./lib/loggers/Logger.js",
 		"./writers/*": "./lib/writers/*.js",
 		"./package.json": "./package.json",
 		"./internal/loggers/*": "./lib/loggers/*.js"

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import logger from "../../lib/index.js";
+import {getLogger, isLogLevelEnabled, setLogLevel, getLogLevel} from "../../lib/index.js";
 import Logger from "../../lib/loggers/Logger.js";
 
 test.serial.afterEach.always((t) => {
@@ -7,27 +7,27 @@ test.serial.afterEach.always((t) => {
 });
 
 test.serial("getLogger", (t) => {
-	const myLogger = logger.getLogger("my-module");
+	const myLogger = getLogger("my-module");
 	t.true(myLogger instanceof Logger, "Returned logger should be Logger instance");
 });
 
-test.serial("isLevelEnabled", (t) => {
+test.serial("isLogLevelEnabled", (t) => {
 	// On info only info,warn,error,silent should be enabled
 	process.env.UI5_LOG_LVL = "info";
-	t.false(logger.isLevelEnabled("silly"));
-	t.false(logger.isLevelEnabled("verbose"));
-	t.false(logger.isLevelEnabled("perf"));
-	t.true(logger.isLevelEnabled("info"));
-	t.true(logger.isLevelEnabled("warn"));
-	t.true(logger.isLevelEnabled("error"));
-	t.true(logger.isLevelEnabled("silent"));
+	t.false(isLogLevelEnabled("silly"));
+	t.false(isLogLevelEnabled("verbose"));
+	t.false(isLogLevelEnabled("perf"));
+	t.true(isLogLevelEnabled("info"));
+	t.true(isLogLevelEnabled("warn"));
+	t.true(isLogLevelEnabled("error"));
+	t.true(isLogLevelEnabled("silent"));
 });
 
 test.serial("setLevel", (t) => {
-	logger.setLevel("silent");
+	setLogLevel("silent");
 	t.is(process.env.UI5_LOG_LVL, "silent", "Log level set correctly");
 });
 
 test.serial("getLevel", (t) => {
-	t.is(logger.getLevel(), "info", "Returned default log level");
+	t.is(getLogLevel(), "info", "Returned default log level");
 });

--- a/test/lib/loggers/Logger.js
+++ b/test/lib/loggers/Logger.js
@@ -97,6 +97,7 @@ test.serial("Legal module names", (t) => {
 	testNotThrows("Module:Name");
 	testNotThrows("@module");
 	testNotThrows("m0-dule_.nAme");
+	testNotThrows("module/name");
 });
 
 test.serial("Illegal module names", (t) => {
@@ -108,7 +109,7 @@ test.serial("Illegal module names", (t) => {
 		}, "Threw with expected error message");
 	}
 	testThrows("module name");
-	testThrows("module/name");
+	testThrows("module\\name");
 	testThrows("näme");
 	testThrows("🧗");
 });

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -17,7 +17,7 @@ test("check number of exports", (t) => {
 
 // Public API contract (exported modules)
 [
-	"loggers/Logger",
+	{exportedSpecifier: "Logger", mappedModule: "../../lib/loggers/Logger.js"},
 	"writers/Console",
 
 	// Internal modules (only to be used by @ui5/* packages)


### PR DESCRIPTION
@ui5/logger functions are now named-exports and got renamed as follows:
* isLevelEnabled => isLogLevelEnabled
* setLevel => setLogLevel
* getLevel => getLogLevel

In addition, the Logger class got renamed:
* @ui5/logger/loggers/Logger => @ui5/logger/Logger

The actual location of the file remains the same. But the package export
and JSDoc got adapted.

Follow-up changes:
* https://github.com/SAP/ui5-fs/pull/478
* https://github.com/SAP/ui5-server/pull/569
* https://github.com/SAP/ui5-builder/pull/877
* https://github.com/SAP/ui5-project/pull/553
* https://github.com/SAP/ui5-cli/pull/599