### PR TITLE
[INTERNAL] writers/Console: Add static 'stop' method to disable all active console writers

### DIFF
--- a/lib/writers/Console.js
+++ b/lib/writers/Console.js
@@ -28,6 +28,7 @@ class Console {
 		this._handleProjectBuildStatusEvent = this.#handleProjectBuildStatusEvent.bind(this);
 		this._handleBuildMetadataEvent = this.#handleBuildMetadataEvent.bind(this);
 		this._handleProjectBuildMetadataEvent = this.#handleProjectBuildMetadataEvent.bind(this);
+		this._handleStop = this.disable.bind(this);
 	}
 
 	/**
@@ -41,6 +42,7 @@ class Console {
 		process.on("ui5.project-build-metadata", this._handleProjectBuildMetadataEvent);
 		process.on("ui5.build-status", this._handleBuildStatusEvent);
 		process.on("ui5.project-build-status", this._handleProjectBuildStatusEvent);
+		process.on("ui5.log.stop-console", this._handleStop);
 	}
 
 	/**
@@ -54,6 +56,7 @@ class Console {
 		process.off("ui5.project-build-metadata", this._handleProjectBuildMetadataEvent);
 		process.off("ui5.build-status", this._handleBuildStatusEvent);
 		process.off("ui5.project-build-status", this._handleProjectBuildStatusEvent);
+		process.off("ui5.log.stop-console", this._handleStop);
 		if (this.#progressBarContainer) {
 			this.#progressBar.stop();
 			this.#progressBarContainer.stop(); // Will fire internal stop event
@@ -365,6 +368,10 @@ class Console {
 		const cH = new Console();
 		cH.enable();
 		return cH;
+	}
+
+	static stop() {
+		process.emit("ui5.log.stop-console");
 	}
 }
 


### PR DESCRIPTION
This is required for example by the UI5 CLI to gracefully disable the
writer in case an exception is thrown. Especially the progress bar needs
to be stopped gracefully in order to restore terminal settings like
"show cursor".