### PR TITLE
[INTERNAL] dependabot auto-merge: update ecosystem check

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,15 +11,17 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'github_actions') }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.auto_merge == null }}
     steps:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+      - name: Approve and auto-merge PRs for minor/patch updates of github-actions
+        if: |
+          steps.dependabot-metadata.outputs.package-ecosystem == 'github-actions' &&
+          contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type)
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Instead of relying on labels, the ecosystem can also be checked via
the fetched dependabot metadata.
This approach prevents issues when dependabot opens a PR but only
moments later assigns the labels. The initial workflow trigger does not
contain information about the labels so the check doesn't succeed.

JIRA: CPOUI5FOUNDATION-717
