### PR TITLE
[INTERNAL] remove v2 branch in pipeline file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- v2
 - main
 
 strategy:


### PR DESCRIPTION
The `v2` branch has its own `azure-pipelines.yml` file, so this config is not needed at all.