### PR TITLE
[INTERNAL] Fix release note generation for v4

### DIFF
--- a/.chglog/release-config.yml
+++ b/.chglog/release-config.yml
@@ -3,7 +3,6 @@ template: RELEASE.tpl.md
 info:
   repository_url: https://github.com/SAP/ui5-logger
 options:
-  tag_filter_pattern: '^v[^0123]' # For release notes ignore versions below v4 to that we always compare the _last v4+_ tag with the current release
   commits:
     filters:
       Type:


### PR DESCRIPTION
`git-chglog --sort semver -c .chglog/release-config.yml --next-tag HEAD HEAD` generates the changelog for the next release as expected with this change

`git-chglog --sort semver -c .chglog/release-config.yml v4.0.0` generates the changelog for the given release tag as expected.

Using the `tag_filter_pattern` option leads to more commits added to the changelog which are already released with older releases.

