### PR TITLE
[FIX] Console: Handle consequitive builds correctly

### DIFF
--- a/lib/writers/Console.js
+++ b/lib/writers/Console.js
@@ -141,6 +141,7 @@ class Console {
 	}
 
 	#handleBuildMetadataEvent({projectsToBuild}) {
+		this.#projectMetadata = new Map();
 		projectsToBuild.forEach((projectName) => {
 			this.#projectMetadata.set(projectName, {
 				buildStarted: false,


### PR DESCRIPTION
Resolves a bug where after a build has completed, any following builds would re-use the project metadata of the previous build, leading to incorrect log messages and clashes if the same project is being built twice.

JIRA: CPOUI5FOUNDATION-941