### PR TITLE
[INTERNAL] Fail-fast "npm ci" if deps require unsupported node version

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: 20.11.0
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
 
     - name: Perform checks and tests
       run: npm test


### PR DESCRIPTION
When upgrading a dependency to a newer version, it might require a different node version than before which could be unsupported by the repo. Unfortunately, this could be easily overseen.

This PR adds the flag --engine-strict to the dependency installation step during the GH Actions job. Incase such a version requirement change, this flag will now fail-fast the job which should attract attention.